### PR TITLE
Change const to var for IE compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const WPJSApiHTTP = function(url, args, method, reqOpts) {
+var WPJSApiHTTP = function(url, args, method, reqOpts) {
     var promise = new Promise(function (resolve, reject) {
         var client = new XMLHttpRequest();
         var uri = url;
@@ -33,7 +33,7 @@ const WPJSApiHTTP = function(url, args, method, reqOpts) {
     return promise;
 }
 
-const WPJSApiEndpoint = {
+var WPJSApiEndpoint = {
     create: function(domain, endpoint) {
         return {
             domain: domain,
@@ -46,7 +46,7 @@ const WPJSApiEndpoint = {
     }
 }
 
-const WPJSApi = {
+var WPJSApi = {
     init: function (url, reqOpts) {
         this.base_url = url;
         this.reqOpts = reqOpts;

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-#Wordpress JS API Wrapper
+# Wordpress JS API Wrapper
 A very simple promise-based javascript wrapper for the Wordpress REST API v2.
 It was created to help the developer focus on getting data from the API and functionality, instead of having to read up on the url scheme for each endpoint when working.
 
-##How to use
+## How to use
 Installation with npm
 ```
 npm install wordpress-js-api-wrapper
@@ -50,7 +50,8 @@ $.get(WPJSApi.Media.getURL(3), function(rsp) {
 
 ```
 
-##Documentation
+## Documentation
+
 | Object | Available methods | Response |
 | ------ | ----------------- | -------- |
 | WPJSApi.Pages | list, get, getURL, listURL   | Array, Object, string, string    |
@@ -64,7 +65,9 @@ $.get(WPJSApi.Media.getURL(3), function(rsp) {
 | WPJSApi.Tags | list, get, getURL, listURL   | Array, Object, string, string    |
 | WPJSApi.Users | list, get, getURL, listURL   | Array, Object, string, string   |
 
+
 | Method | Parameters | ... |
+| ------ | ----------------- | -------- |
 | list(args)  | args object | |
 | get(id, args)     | id int, args array | Pass extra parameters using the args array, will be appended to end of url-string. |
 | listURL(args)     | args object | |


### PR DESCRIPTION
After struggling to figure out why my webpacked site was totally dead on IE <= 10 I discovered the usage of `const` in this plugin. Since babel-loader ignores all node modules, the `const`'s in this file were not being transpiled to `var`'s.